### PR TITLE
Breaking change due to missing character

### DIFF
--- a/addons/AsepriteWizard/importers/multiple_import_plugin_base.gd
+++ b/addons/AsepriteWizard/importers/multiple_import_plugin_base.gd
@@ -59,7 +59,7 @@ func _import(source_file, save_path, options, platform_variants, gen_files):
 
 	if layers_resources_folder.is_relative_path():
 	    var source_base_dir = source_file.get_base_dir()
-	    layer_resources_folder = source_base_dir.path_join(layers_resources_folder).simplify_path()
+	    layers_resources_folder = source_base_dir.path_join(layers_resources_folder).simplify_path()
 
 	var import_options = _get_base_import_options(options)
 	import_options["source"] = source_file


### PR DESCRIPTION
Noticed while I was executing my pipeline that the aseprite plugin wasn't working because an "s" was missing.